### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 django>=1.7
-algoliasearch>=2.0,<3.0
+algoliasearch==3.0.0
 # dev dependencies
 pypandoc
 wheel

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     version=VERSION,
     license='MIT License',
     packages=find_packages(exclude=['tests']),
-    install_requires=['django>=1.7', 'algoliasearch>=2.0,<3.0'],
+    install_requires=['django>=1.7', 'algoliasearch==3.0.0'],
     description='Algolia Search integration for Django',
     long_description=README,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
| Bug fix?          | yes
| New feature?      | no    
| BC breaks?        | no     
| Related Issue     |  - 
| Need Doc update   | no

Update requirements to use new algoliasearch 

## What problem is this fixing?
Current version cannot be installed alongside algoliasearch 3.x
